### PR TITLE
removed duplicate `hostname` of home router's response in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Body:
 {
     "data": {
         "message": "Hello, World!",
-        "hostname": "hostname": "Yusufs-MBP-2"
+        "hostname": "Yusufs-MBP-2"
     }
 }
 ```


### PR DESCRIPTION
Hi Yusuf, 

I have removed the removed duplicate `hostname` key of home router's response in readme.md

Earlier response:
```
{
    "data": {
        "message": "Hello, World!",
        "hostname": "hostname": "Yusufs-MBP-2"
    }
}
```

Changes I have made:
```
{
    "data": {
        "message": "Hello, World!",
        "hostname": "Yusufs-MBP-2"
    }
}
```

Thank you ):